### PR TITLE
SLING-9896 handle PersistenceExceptions explicitly and throw a 405

### DIFF
--- a/src/main/java/org/apache/sling/servlets/post/PostOperation.java
+++ b/src/main/java/org/apache/sling/servlets/post/PostOperation.java
@@ -19,6 +19,7 @@
 package org.apache.sling.servlets.post;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.PersistenceException;
 
 /**
  * The <code>PostOperation</code> interface defines the service API to be
@@ -72,14 +73,8 @@ public interface PostOperation {
      * @param processors The {@link SlingPostProcessor} services to be called
      *            after applying the operation. This may be <code>null</code> if
      *            there are none.
-     * @throws org.apache.sling.api.resource.ResourceNotFoundException May be
-     *             thrown if the operation requires an existing request
-     *             resource. If this exception is thrown the Sling POST servlet
-     *             sends back a <code>404/NOT FOUND</code> response to the
-     *             client.
-     * @throws org.apache.sling.api.SlingException May be thrown if an error
-     *             occurrs running the operation.
+     * @throws PersistenceException in case of errors during persistence of changes
      */
     void run(SlingHttpServletRequest request, PostResponse response,
-            SlingPostProcessor[] processors);
+            SlingPostProcessor[] processors) throws PersistenceException;
 }

--- a/src/main/java/org/apache/sling/servlets/post/impl/SlingPostServlet.java
+++ b/src/main/java/org/apache/sling/servlets/post/impl/SlingPostServlet.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.ResourceNotFoundException;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
@@ -234,6 +235,11 @@ public class SlingPostServlet extends SlingAllMethodsServlet {
             } catch (ResourceNotFoundException rnfe) {
                 htmlResponse.setStatus(HttpServletResponse.SC_NOT_FOUND,
                     rnfe.getMessage());
+            } catch (final PersistenceException pe) {
+                log.warn("PersistenceException while handling POST "
+                  + request.getResource().getPath() + " with "
+                  + operation.getClass().getName(), pe);
+                htmlResponse.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED,"invalid POST request");
             } catch (final Exception exception) {
                 log.warn("Exception while handling POST "
                     + request.getResource().getPath() + " with "

--- a/src/test/java/org/apache/sling/servlets/post/AbstractPostOperationTest.java
+++ b/src/test/java/org/apache/sling/servlets/post/AbstractPostOperationTest.java
@@ -17,6 +17,7 @@
 package org.apache.sling.servlets.post;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.commons.testing.sling.MockResourceResolver;
 import org.apache.sling.servlets.post.impl.helper.MockSlingHttpServlet3Request;
 import org.junit.Test;
@@ -30,7 +31,7 @@ import static org.junit.Assert.*;
 public class AbstractPostOperationTest {
 
     @Test
-    public void testRemainingPostfixCausesFailure() {
+    public void testRemainingPostfixCausesFailure() throws PersistenceException {
         TestingResourceResolver resourceResolver = new TestingResourceResolver();
 
         MockSlingHttpServlet3Request request = new MockSlingHttpServlet3Request("/test", null, null, null, null);
@@ -52,7 +53,7 @@ public class AbstractPostOperationTest {
     }
 
     @Test
-    public void testNoRemainingPostfixIsSuccessful() {
+    public void testNoRemainingPostfixIsSuccessful() throws PersistenceException {
         TestingResourceResolver resourceResolver = new TestingResourceResolver();
 
         MockSlingHttpServlet3Request request = new MockSlingHttpServlet3Request("/test", null, null, null, null);
@@ -73,7 +74,7 @@ public class AbstractPostOperationTest {
     }
 
     @Test
-    public void testRemainingPostfixWithoutUnPostfixedIsSuccessful() {
+    public void testRemainingPostfixWithoutUnPostfixedIsSuccessful() throws PersistenceException {
         TestingResourceResolver resourceResolver = new TestingResourceResolver();
 
         MockSlingHttpServlet3Request request = new MockSlingHttpServlet3Request("/test", null, null, null, null);


### PR DESCRIPTION
I would love to clearly distinguish between multiple root causes, but this requires at least a major rewrite of the code, and I am not sure if that is possible at all. The JCRSupportImpl [1] catches all kinds of JCR exceptions (mostly RepositoryExceptions) and wraps them into PersistenceExceptions. From my POV splitting that up into "real ISEs" (server side state is already corrupt) and "exceptions caused by invalid date sent from the client" (in which the server-side is consistent, but not the input data) is likely impossible.

[1] https://github.com/apache/sling-org-apache-sling-servlets-post/blob/master/src/main/java/org/apache/sling/servlets/post/impl/helper/JCRSupportImpl.java