### PR TITLE
SLING-10087 convert more persistenceexceptions

### DIFF
--- a/src/main/java/org/apache/sling/servlets/post/PostOperation.java
+++ b/src/main/java/org/apache/sling/servlets/post/PostOperation.java
@@ -19,6 +19,7 @@
 package org.apache.sling.servlets.post;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.servlets.post.exceptions.PreconditionViolatedPersistenceException;
 import org.apache.sling.servlets.post.exceptions.TemporaryPersistenceException;
 
@@ -74,6 +75,7 @@ public interface PostOperation {
      * @param processors The {@link SlingPostProcessor} services to be called
      *            after applying the operation. This may be <code>null</code> if
      *            there are none.
+     * @throws PersistenceException 
      * @throws org.apache.sling.api.resource.ResourceNotFoundException May be
      *             thrown if the operation requires an existing request
      *             resource. If this exception is thrown the Sling POST servlet
@@ -83,5 +85,5 @@ public interface PostOperation {
      *             occurrs running the operation.
      */
     void run(SlingHttpServletRequest request, PostResponse response,
-            SlingPostProcessor[] processors) throws PreconditionViolatedPersistenceException, TemporaryPersistenceException;
+            SlingPostProcessor[] processors) throws PreconditionViolatedPersistenceException, TemporaryPersistenceException, PersistenceException;
 }

--- a/src/main/java/org/apache/sling/servlets/post/exceptions/PreconditionViolatedPersistenceException.java
+++ b/src/main/java/org/apache/sling/servlets/post/exceptions/PreconditionViolatedPersistenceException.java
@@ -43,6 +43,10 @@ public class PreconditionViolatedPersistenceException extends PersistenceExcepti
             super(msg,cause,resourcePath,propertyName);
             
             }
+
+public PreconditionViolatedPersistenceException(String msg) {
+    super(msg);
+}
   
 
 }

--- a/src/main/java/org/apache/sling/servlets/post/impl/SlingPostServlet.java
+++ b/src/main/java/org/apache/sling/servlets/post/impl/SlingPostServlet.java
@@ -245,8 +245,8 @@ public class SlingPostServlet extends SlingAllMethodsServlet {
                 htmlResponse.setStatus(HttpServletResponse.SC_NOT_FOUND,
                     rnfe.getMessage());
             } catch (final PreconditionViolatedPersistenceException e) {
-                log.warn("Exception while handling POST {} with {}",
-                        new Object[] {request.getResource().getPath(),operation.getClass().getName()},e);
+                log.warn("Exception while handling POST on path [{}] with operation [{}]",
+                        request.getResource().getPath(),operation.getClass().getName(),e);
                 if (backwardsCompatibleStatuscode) {
                     htmlResponse.setError(e);
                 } else {
@@ -254,17 +254,17 @@ public class SlingPostServlet extends SlingAllMethodsServlet {
                 }
             } catch (final PersistenceException e) {
                 // also catches the  RetryableOperationException, as the handling is the same
-                log.warn("Exception while handling POST {} with {}",
-                        new Object[] {request.getResource().getPath(),operation.getClass().getName()},e);
+                log.warn("Exception while handling POST on path [{}] with operation [{}]",
+                        request.getResource().getPath(),operation.getClass().getName(),e);
                 if (backwardsCompatibleStatuscode) {
                     htmlResponse.setError(e);
                 } else {
                     htmlResponse.setStatus(HttpServletResponse.SC_CONFLICT, "repository state conflicting with request");
                 }
-            } catch (final Exception exception) {
-                log.warn("Exception while handling POST {} with {}",
-                        new Object[] {request.getResource().getPath(),operation.getClass().getName()},exception);
-                htmlResponse.setError(exception);
+            } catch (final Exception e) {
+                log.warn("Exception while handling POST on path [{}] with operation [{}]",
+                        request.getResource().getPath(),operation.getClass().getName(),e);
+                htmlResponse.setError(e);
             }
 
         }

--- a/src/main/java/org/apache/sling/servlets/post/impl/helper/SlingPropertyValueHandler.java
+++ b/src/main/java/org/apache/sling/servlets/post/impl/helper/SlingPropertyValueHandler.java
@@ -32,6 +32,7 @@ import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.SlingPostConstants;
+import org.apache.sling.servlets.post.exceptions.PreconditionViolatedPersistenceException;
 
 /**
  * Sets a property on the given resource, in some cases with a specific type and
@@ -111,7 +112,7 @@ public class SlingPropertyValueHandler {
         mod.node = jcrSupport.getNode(parent);
         mod.valueMap = parent.adaptTo(ModifiableValueMap.class);
         if ( mod.valueMap == null ) {
-            throw new PersistenceException("Resource at '" + parent.getPath() + "' is not modifiable.");
+            throw new PreconditionViolatedPersistenceException("Resource at '" + parent.getPath() + "' is not modifiable.");
         }
 
         final String name = prop.getName();

--- a/src/main/java/org/apache/sling/servlets/post/impl/operations/AbstractPostOperation.java
+++ b/src/main/java/org/apache/sling/servlets/post/impl/operations/AbstractPostOperation.java
@@ -135,10 +135,8 @@ public abstract class AbstractPostOperation implements PostOperation {
             if (modificationSourcesContainingPostfix.size() > 0) {
                 for (final Map.Entry<String, String> sourceToCheck : modificationSourcesContainingPostfix.entrySet()) {
                     if (allModificationSources.contains(sourceToCheck.getKey())) {
-                        response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                                "Postfix-containing path " + sourceToCheck.getValue() +
+                        throw new PersistenceException("Postfix-containing path " + sourceToCheck.getValue() +
                                 " contained in the modification list. Check configuration.");
-                        return;
                     }
                 }
             }


### PR DESCRIPTION
SLING-9896 did not cover a codepath in the ModificationOperation where the exception handling configured response object was configured instead of doing everything in the SlingPostSerlvet. Also improved some exception messages which were not properly logged.