### PR TITLE
SLING-10169: Enabling servlet.post.autoCheckout breaks POST requests when one of the ancestor nodes is not accessible

### DIFF
--- a/src/main/java/org/apache/sling/servlets/post/impl/helper/JCRSupportImpl.java
+++ b/src/main/java/org/apache/sling/servlets/post/impl/helper/JCRSupportImpl.java
@@ -212,8 +212,8 @@ public class JCRSupportImpl {
         try {
             node = node.getParent();
             return findVersionableAncestor(node);
-        } catch (ItemNotFoundException e) {
-            // top-level
+        } catch (ItemNotFoundException | AccessDeniedException e ) {
+            // top-level or parent not accessible, stop looking for a versionable ancestor
             return null;
         }
     }


### PR DESCRIPTION
Fixed.