### PR TITLE
SLING-10610 Support the @ValueFrom suffix for the name parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,12 @@
             <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.servlet-helpers</artifactId>
+            <version>1.4.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/test/java/org/apache/sling/servlets/post/impl/helper/DefaultNodeNameGeneratorTest.java
+++ b/src/test/java/org/apache/sling/servlets/post/impl/helper/DefaultNodeNameGeneratorTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.servlets.post.impl.helper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
+import org.apache.sling.servlets.post.NodeNameGenerator;
+import org.junit.Test;
+
+/**
+ * Test node name generator
+ */
+public class DefaultNodeNameGeneratorTest {
+
+    protected String nodeName(Map<String, Object> parameterMap) {
+        return nodeName(parameterMap, false);
+    }
+    protected String nodeName(Map<String, Object> parameterMap, boolean requirePrefix) {
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(null);
+        request.setParameterMap(parameterMap);
+
+        String basePath = null;
+        NodeNameGenerator defaultNodeNameGenerator = null;
+
+        String[] parameterNames = new String[] {
+                "title",
+                "sling:subject"
+            };
+        int maxNameLength = 10;
+        NodeNameGenerator nodeNameGenerator = new DefaultNodeNameGenerator(
+                parameterNames, 
+                maxNameLength);
+        return nodeNameGenerator.getNodeName(request, basePath, requirePrefix, defaultNodeNameGenerator);
+    }
+
+    @Test
+    public void testNameDefault() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("message", "Hello");
+        String nodeName = nodeName(map);
+        assertTrue(nodeName.matches("\\d+_\\d+"));
+    }
+
+    @Test
+    public void testNameHint() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":nameHint", "Hello");
+        String nodeName = nodeName(map);
+        assertEquals("hello", nodeName);
+    }
+
+    @Test
+    public void testName() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":name", "Hello");
+        String nodeName = nodeName(map);
+        assertEquals("Hello", nodeName);
+    }
+
+    @Test
+    public void testNameHintTrimmed() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":nameHint", "HelloWorldTooLong");
+        String nodeName = nodeName(map);
+        assertEquals("helloworld", nodeName);
+    }
+
+    @Test
+    public void testNameFromTitle() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("title", "Hello");
+        String nodeName = nodeName(map);
+        assertEquals("hello", nodeName);
+    }
+
+    @Test
+    public void testNameFromTitleWithPrefix() {
+        // 1. should not find any param and fallback to the default
+        Map<String, Object> map = new HashMap<>();
+        map.put("title", "Hello");
+        String nodeName = nodeName(map, true);
+        assertTrue(nodeName.matches("\\d+_\\d+"));
+
+        // 2. should find a param and use it
+        map.clear();
+        map.put("./title", "Hello");
+        nodeName = nodeName(map, true);
+        assertEquals("hello", nodeName);
+    }
+
+    @Test
+    public void testNameFromSubject() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("sling:message", "Hello");
+        map.put("sling:subject", "World");
+        String nodeName = nodeName(map);
+        assertEquals("world", nodeName);
+    }
+
+    @Test
+    public void testNameHintFilter() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":nameHint", "H$lloW#rld");
+        String nodeName = nodeName(map);
+        assertEquals("h_llow_rld", nodeName);
+    }
+
+    /**
+     * SLING-10610
+     */
+    @Test
+    public void testNameHintValueFrom() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":nameHint@ValueFrom", "message");
+        map.put("message", "Hello");
+        String nodeName = nodeName(map);
+        assertEquals("hello", nodeName);
+    }
+
+    /**
+     * SLING-10610
+     */
+    @Test
+    public void testNameValueFrom() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":name@ValueFrom", "message");
+        map.put("message", "Hello");
+        String nodeName = nodeName(map);
+        assertEquals("Hello", nodeName);
+    }
+
+    @Test
+    public void testNameFromSubjectValueFrom() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("sling:message", "Hello");
+        map.put("sling:subject@ValueFrom", "sling:message");
+        String nodeName = nodeName(map);
+        assertEquals("hello", nodeName);
+    }
+
+}

--- a/src/test/java/org/apache/sling/servlets/post/impl/helper/DefaultNodeNameGeneratorTest.java
+++ b/src/test/java/org/apache/sling/servlets/post/impl/helper/DefaultNodeNameGeneratorTest.java
@@ -19,6 +19,7 @@ package org.apache.sling.servlets.post.impl.helper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,86 +53,69 @@ public class DefaultNodeNameGeneratorTest {
         return nodeNameGenerator.getNodeName(request, basePath, requirePrefix, defaultNodeNameGenerator);
     }
 
+    protected void assertDefaultName(Map<String, Object> parameterMap) {
+        assertDefaultName(parameterMap, false);
+    }
+    protected void assertDefaultName(Map<String, Object> parameterMap, boolean requirePrefix) {
+        String nodeName = nodeName(parameterMap, requirePrefix);
+        assertTrue(nodeName.matches("\\d+_\\d+"));
+    }
+
+    protected void assertExpectedName(Map<String, Object> parameterMap, String expectedName) {
+        assertExpectedName(parameterMap, expectedName, false);
+    }
+    protected void assertExpectedName(Map<String, Object> parameterMap, String expectedName, boolean requirePrefix) {
+        String nodeName = nodeName(parameterMap, requirePrefix);
+        assertEquals(expectedName, nodeName);
+    }
+
     @Test
     public void testNameDefault() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("message", "Hello");
-        String nodeName = nodeName(map);
-        assertTrue(nodeName.matches("\\d+_\\d+"));
+        assertDefaultName(Collections.singletonMap("message", "Hello"));
     }
 
     @Test
     public void testNameHint() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(":nameHint", "Hello");
-        String nodeName = nodeName(map);
-        assertEquals("hello", nodeName);
+        assertExpectedName(Collections.singletonMap(":nameHint", "Hello"), "hello");
     }
 
     @Test
     public void testNameHintEmpty() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(":nameHint", "");
-        String nodeName = nodeName(map);
-        // empty name should be skipped and fallback to the default
-        assertTrue(nodeName.matches("\\d+_\\d+"));
+        assertDefaultName(Collections.singletonMap(":nameHint", ""));
     }
 
     @Test
     public void testName() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(":name", "Hello");
-        String nodeName = nodeName(map);
-        assertEquals("Hello", nodeName);
+        assertExpectedName(Collections.singletonMap(":name", "Hello"), "Hello");
     }
 
     @Test
     public void testNameEmpty() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(":name", "");
-        String nodeName = nodeName(map);
-        // empty name should be skipped and fallback to the default
-        assertTrue(nodeName.matches("\\d+_\\d+"));
+        assertDefaultName(Collections.singletonMap(":name", ""));
     }
 
     @Test
     public void testNameHintTrimmed() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(":nameHint", "HelloWorldTooLong");
-        String nodeName = nodeName(map);
-        assertEquals("helloworld", nodeName);
+        assertExpectedName(Collections.singletonMap(":nameHint", "HelloWorldTooLong"), "helloworld");
     }
 
     @Test
     public void testNameFromTitle() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("title", "Hello");
-        String nodeName = nodeName(map);
-        assertEquals("hello", nodeName);
+        assertExpectedName(Collections.singletonMap("title", "Hello"), "hello");
     }
 
     @Test
     public void testNameFromTitleEmpty() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("title", "");
-        String nodeName = nodeName(map);
-        // empty name should be skipped and fallback to the default
-        assertTrue(nodeName.matches("\\d+_\\d+"));
+        assertDefaultName(Collections.singletonMap("title", ""));
     }
 
     @Test
     public void testNameFromTitleWithPrefix() {
         // 1. should not find any param and fallback to the default
-        Map<String, Object> map = new HashMap<>();
-        map.put("title", "Hello");
-        String nodeName = nodeName(map, true);
-        assertTrue(nodeName.matches("\\d+_\\d+"));
+        assertDefaultName(Collections.singletonMap("title", "Hello"), true);
 
         // 2. should find a param and use it
-        map.clear();
-        map.put("./title", "Hello");
-        nodeName = nodeName(map, true);
-        assertEquals("hello", nodeName);
+        assertExpectedName(Collections.singletonMap("./title", "Hello"), "hello", true);
     }
 
     @Test
@@ -139,16 +123,12 @@ public class DefaultNodeNameGeneratorTest {
         Map<String, Object> map = new HashMap<>();
         map.put("sling:message", "Hello");
         map.put("sling:subject", "World");
-        String nodeName = nodeName(map);
-        assertEquals("world", nodeName);
+        assertExpectedName(map, "world");
     }
 
     @Test
     public void testNameHintFilter() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(":nameHint", "H$lloW#rld");
-        String nodeName = nodeName(map);
-        assertEquals("h_llow_rld", nodeName);
+        assertExpectedName(Collections.singletonMap(":nameHint", "H$lloW#rld"), "h_llow_rld");
     }
 
     /**
@@ -159,17 +139,12 @@ public class DefaultNodeNameGeneratorTest {
         Map<String, Object> map = new HashMap<>();
         map.put(":nameHint@ValueFrom", "message");
         map.put("message", "Hello");
-        String nodeName = nodeName(map);
-        assertEquals("hello", nodeName);
+        assertExpectedName(map, "hello");
     }
 
     @Test
     public void testNameHintValueFromEmpty() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(":nameHint@ValueFrom", "");
-        String nodeName = nodeName(map);
-        // empty name should be skipped and fallback to the default
-        assertTrue(nodeName.matches("\\d+_\\d+"));
+        assertDefaultName(Collections.singletonMap(":nameHint@ValueFrom", ""));
     }
 
     @Test
@@ -177,9 +152,7 @@ public class DefaultNodeNameGeneratorTest {
         Map<String, Object> map = new HashMap<>();
         map.put(":nameHint@ValueFrom", "message");
         map.put("message", "");
-        String nodeName = nodeName(map);
-        // empty name should be skipped and fallback to the default
-        assertTrue(nodeName.matches("\\d+_\\d+"));
+        assertDefaultName(map);
     }
 
     /**
@@ -190,8 +163,7 @@ public class DefaultNodeNameGeneratorTest {
         Map<String, Object> map = new HashMap<>();
         map.put(":name@ValueFrom", "message");
         map.put("message", "Hello");
-        String nodeName = nodeName(map);
-        assertEquals("Hello", nodeName);
+        assertExpectedName(map, "Hello");
     }
 
     @Test
@@ -199,17 +171,12 @@ public class DefaultNodeNameGeneratorTest {
         Map<String, Object> map = new HashMap<>();
         map.put("sling:message", "Hello");
         map.put("sling:subject@ValueFrom", "sling:message");
-        String nodeName = nodeName(map);
-        assertEquals("hello", nodeName);
+        assertExpectedName(map, "hello");
     }
 
     @Test
     public void testNameFromSubjectValueFromEmpty() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("sling:subject@ValueFrom", "");
-        String nodeName = nodeName(map);
-        // empty name should be skipped and fallback to the default
-        assertTrue(nodeName.matches("\\d+_\\d+"));
+        assertDefaultName(Collections.singletonMap("sling:subject@ValueFrom", ""));
     }
 
     @Test
@@ -217,9 +184,7 @@ public class DefaultNodeNameGeneratorTest {
         Map<String, Object> map = new HashMap<>();
         map.put("sling:message", "");
         map.put("sling:subject@ValueFrom", "sling:message");
-        String nodeName = nodeName(map);
-        // empty name should be skipped and fallback to the default
-        assertTrue(nodeName.matches("\\d+_\\d+"));
+        assertDefaultName(map);
     }
 
 }

--- a/src/test/java/org/apache/sling/servlets/post/impl/helper/DefaultNodeNameGeneratorTest.java
+++ b/src/test/java/org/apache/sling/servlets/post/impl/helper/DefaultNodeNameGeneratorTest.java
@@ -69,11 +69,29 @@ public class DefaultNodeNameGeneratorTest {
     }
 
     @Test
+    public void testNameHintEmpty() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":nameHint", "");
+        String nodeName = nodeName(map);
+        // empty name should be skipped and fallback to the default
+        assertTrue(nodeName.matches("\\d+_\\d+"));
+    }
+
+    @Test
     public void testName() {
         Map<String, Object> map = new HashMap<>();
         map.put(":name", "Hello");
         String nodeName = nodeName(map);
         assertEquals("Hello", nodeName);
+    }
+
+    @Test
+    public void testNameEmpty() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":name", "");
+        String nodeName = nodeName(map);
+        // empty name should be skipped and fallback to the default
+        assertTrue(nodeName.matches("\\d+_\\d+"));
     }
 
     @Test
@@ -90,6 +108,15 @@ public class DefaultNodeNameGeneratorTest {
         map.put("title", "Hello");
         String nodeName = nodeName(map);
         assertEquals("hello", nodeName);
+    }
+
+    @Test
+    public void testNameFromTitleEmpty() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("title", "");
+        String nodeName = nodeName(map);
+        // empty name should be skipped and fallback to the default
+        assertTrue(nodeName.matches("\\d+_\\d+"));
     }
 
     @Test
@@ -136,6 +163,25 @@ public class DefaultNodeNameGeneratorTest {
         assertEquals("hello", nodeName);
     }
 
+    @Test
+    public void testNameHintValueFromEmpty() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":nameHint@ValueFrom", "");
+        String nodeName = nodeName(map);
+        // empty name should be skipped and fallback to the default
+        assertTrue(nodeName.matches("\\d+_\\d+"));
+    }
+
+    @Test
+    public void testNameHintValueFromEmptyRef() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(":nameHint@ValueFrom", "message");
+        map.put("message", "");
+        String nodeName = nodeName(map);
+        // empty name should be skipped and fallback to the default
+        assertTrue(nodeName.matches("\\d+_\\d+"));
+    }
+
     /**
      * SLING-10610
      */
@@ -155,6 +201,25 @@ public class DefaultNodeNameGeneratorTest {
         map.put("sling:subject@ValueFrom", "sling:message");
         String nodeName = nodeName(map);
         assertEquals("hello", nodeName);
+    }
+
+    @Test
+    public void testNameFromSubjectValueFromEmpty() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("sling:subject@ValueFrom", "");
+        String nodeName = nodeName(map);
+        // empty name should be skipped and fallback to the default
+        assertTrue(nodeName.matches("\\d+_\\d+"));
+    }
+
+    @Test
+    public void testNameFromSubjectValueFromEmptyRef() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("sling:message", "");
+        map.put("sling:subject@ValueFrom", "sling:message");
+        String nodeName = nodeName(map);
+        // empty name should be skipped and fallback to the default
+        assertTrue(nodeName.matches("\\d+_\\d+"));
     }
 
 }


### PR DESCRIPTION
The :name and :nameHint properties were not considering or handling the @ValueFrom suffix. This makes reusing the same text for some property and the :name/:nameHint value require a form that uses the @ValueFrom suffix on the other field.

See [SLING-10610](https://issues.apache.org/jira/browse/SLING-10610) for more details
