### PR TITLE
SLING-11971 Adding ability to view post processor processing time

### DIFF
--- a/src/main/java/org/apache/sling/servlets/post/impl/operations/AbstractPostOperation.java
+++ b/src/main/java/org/apache/sling/servlets/post/impl/operations/AbstractPostOperation.java
@@ -106,6 +106,7 @@ public abstract class AbstractPostOperation implements PostOperation {
             try {
                 if (processors != null) {
                     for (SlingPostProcessor processor : processors) {
+                        request.getRequestProgressTracker().log("Calling Sling Post Processor {0}", processor.getClass().getName());
                         processor.process(request, changes);
                     }
                 }


### PR DESCRIPTION
SLING-11971

Adding the ability to review the post processors that are executed and the time it takes for them to process. This will be visible in the /system/console/requests page for the given request. 