### PR TITLE
fix(security): sanitize redirect URL in log message to prevent log injection

### DIFF
--- a/src/main/java/org/apache/sling/servlets/post/impl/SlingPostServlet.java
+++ b/src/main/java/org/apache/sling/servlets/post/impl/SlingPostServlet.java
@@ -463,9 +463,10 @@ public class SlingPostServlet extends SlingJakartaAllMethodsServlet {
                 URI redirectUri = new URI(encodedURL);
                 if (redirectUri.getAuthority() != null) {
                     // if it has a host information
+                    final String sanitizedResult = result.replace('\r', '_').replace('\n', '_');
                     log.warn(
                             "redirect target ({}) does include host information ({}). This is not allowed for security reasons!",
-                            result,
+                            sanitizedResult,
                             redirectUri.getAuthority());
                     return null;
                 }


### PR DESCRIPTION
Prevents a log injection vulnerability where a crafted redirect target containing CR/LF characters could be used to forge log lines.

- Introduced `sanitizedResult` that replaces `\r` and `\n` with `_` before logging the disallowed redirect target
- The actual security check and `null` return are unchanged; only the log output is sanitized

Co-authored-by: Maia <maia@noreply>